### PR TITLE
Hack to work with unencrypted files

### DIFF
--- a/DeS-SaveEdit/DeS-SaveEdit.vbproj
+++ b/DeS-SaveEdit/DeS-SaveEdit.vbproj
@@ -78,7 +78,7 @@
     <GenerateManifests>true</GenerateManifests>
   </PropertyGroup>
   <PropertyGroup>
-    <SignManifests>true</SignManifests>
+    <SignManifests>false</SignManifests>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationManifest>My Project\app.manifest</ApplicationManifest>

--- a/DeS-SaveEdit/DeS.vb
+++ b/DeS-SaveEdit/DeS.vb
@@ -112,16 +112,17 @@ Public Class DeS
     Private Sub btnDeSOpen_Click(sender As System.Object, e As System.EventArgs) Handles btnDeSOpen.Click
 
 
-        Try
+        ' Try
             filename = "PARAM.SFO"
             bytes = System.IO.File.ReadAllBytes(txtDeSFolder.Text & "\" & filename)
 
             txtProfNum.Text = bytes(&H570)
 
             manager = New Ps3SaveManager(txtDeSFolder.Text, SecureID)
-            filename = "1USER.DAT"
+            filename = "\USER.DAT"
 
-            file = manager.Files.FirstOrDefault(Function(t) t.PFDEntry.file_name = filename)
+            ' file = manager.Files.FirstOrDefault(Function(t) t.PFDEntry.file_name = filename)
+            file = manager.Files.FirstOrDefault(Function(t) t.FilePath.EndsWith(filename))
             bytes = file.DecryptToBytes
 
             txtWorld.Text = Convert.ToUInt16(bytes(&H4))
@@ -244,22 +245,22 @@ Public Class DeS
 
             chkArchSealed.Checked = Not OneByteAnd(&H1F965, &H40)
 
-        Catch ex As Exception
-            MsgBox("Failed to open save.  Either you or I did something dumb..." & ex.Message)
-        End Try
+        ' Catch ex As Exception
+        '     MsgBox("Failed to open save.  Either you or I did something dumb..." & ex.Message)
+        ' End Try
 
     End Sub
     Private Sub btnDeSSave_Click(sender As System.Object, e As System.EventArgs) Handles btnDeSSave.Click
 
-        Try
-            filename = "PARAM.SFO"
-            bytes = System.IO.File.ReadAllBytes(txtDeSFolder.Text & "\" & filename)
-            bytes(&H570) = Val(txtProfNum.Text)
-            System.IO.File.WriteAllBytes(txtDeSFolder.Text & "\" & filename, bytes)
+        ' Try
+            ' filename = "PARAM.SFO"
+            ' bytes = System.IO.File.ReadAllBytes(txtDeSFolder.Text & "\" & filename)
+            ' bytes(&H570) = Val(txtProfNum.Text)
+            ' System.IO.File.WriteAllBytes(txtDeSFolder.Text & "\" & filename, bytes)
 
 
-            filename = "1USER.DAT"
-            file = manager.Files.FirstOrDefault(Function(t) t.PFDEntry.file_name = filename)
+            filename = "\USER.DAT"
+            file = manager.Files.FirstOrDefault(Function(t) t.FilePath.EndsWith(filename))
             bytes = file.DecryptToBytes
 
             bytes(&H4) = Val(txtWorld.Text)
@@ -430,31 +431,31 @@ Public Class DeS
             bytes(&H1F965) = (bytes(&H1F965) And &HBF) Or &H40 * ((Not chkArchSealed.Checked) * -1)
 
             file.Encrypt(bytes)
-            manager.ReBuildChanges()
+            ' manager.ReBuildChanges()
 
 
 
 
-            filename = "104USER.DAT"
-            file = manager.Files.FirstOrDefault(Function(t) t.PFDEntry.file_name = filename)
-            bytes = file.DecryptToBytes
+            ' filename = "104USER.DAT"
+            ' file = manager.Files.FirstOrDefault(Function(t) t.PFDEntry.file_name = filename)
+            ' bytes = file.DecryptToBytes
 
-            For i = 0 To &H10
-                If i < txtName.Text.Length Then
-                    bytes(&H21D + i * 2) = Microsoft.VisualBasic.Asc(txtName.Text(i))
-                Else
-                    bytes(&H21D + i * 2) = 0
-                End If
-                bytes(&H21D + i * 2 + 1) = 0
-            Next
+            ' For i = 0 To &H10
+            '     If i < txtName.Text.Length Then
+            '         bytes(&H21D + i * 2) = Microsoft.VisualBasic.Asc(txtName.Text(i))
+            '     Else
+            '         bytes(&H21D + i * 2) = 0
+            '     End If
+            '     bytes(&H21D + i * 2 + 1) = 0
+            ' Next
 
-            file.Encrypt(bytes)
-            manager.ReBuildChanges()
+            ' file.Encrypt(bytes)
+            ' manager.ReBuildChanges()
 
             MsgBox("Save Completed")
-        Catch ex As Exception
-            MsgBox("Save failed, no specific reason.  Either you or I did something dumb..." & ex.Message)
-        End Try
+        ' Catch ex As Exception
+        '     MsgBox("Save failed, no specific reason.  Either you or I did something dumb..." & ex.Message)
+        ' End Try
     End Sub
 
     Private Sub txtDeSBrowse_Click(sender As System.Object, e As System.EventArgs) Handles btnDeSBrowse.Click

--- a/DeS-SaveEdit/Ps3File.vb
+++ b/DeS-SaveEdit/Ps3File.vb
@@ -49,7 +49,8 @@ Namespace PS3FileSystem
         End Function
 
         Public Function DecryptToBytes() As Byte()
-            Return Manager.Param_PFD.DecryptToBytes(FilePath)
+            ' Return Manager.Param_PFD.DecryptToBytes(FilePath)
+            Return File.ReadAllBytes(FilePath)
         End Function
 
         Public Function DecryptToStream() As Stream
@@ -61,7 +62,13 @@ Namespace PS3FileSystem
         End Function
 
         Public Function Encrypt(data As Byte()) As Boolean
-            Return Manager.Param_PFD.Encrypt(data, Me)
+            ' Return Manager.Param_PFD.Encrypt(data, Me)
+            Try
+                File.WriteAllBytes(FilePath, data)
+                Return True
+            Catch
+                Return False
+            End Try
         End Function
 
         Public Function EncryptToBytes() As Byte()

--- a/DeS-SaveEdit/Ps3SaveManager.vb
+++ b/DeS-SaveEdit/Ps3SaveManager.vb
@@ -11,24 +11,25 @@ Namespace PS3FileSystem
             If Not Directory.Exists(savedir) Then
                 Throw New Exception("No such directory exist!")
             End If
-            If Not File.Exists(savedir & "\PARAM.PFD") Then
-                Throw New Exception("Rootdirectory does not contain any PARAM.PFD, Please load a valid directory")
-            End If
+            ' If Not File.Exists(savedir & "\PARAM.PFD") Then
+            '     Throw New Exception("Rootdirectory does not contain any PARAM.PFD, Please load a valid directory")
+            ' End If
             If Not File.Exists(savedir & "\PARAM.SFO") Then
                 Throw New Exception("Rootdirectory does not contain any PARAM.SFO, Please load a valid directory")
             End If
-            Param_PFD = New Param_PFD(savedir & "\PARAM.PFD")
+            ' Param_PFD = New Param_PFD(savedir & "\PARAM.PFD")
             Param_SFO = New PARAM_SFO(savedir & "\PARAM.SFO")
-            If securefileid IsNot Nothing Then
-                Param_PFD.SecureFileID = securefileid
-            End If
+            ' If securefileid IsNot Nothing Then
+            '     Param_PFD.SecureFileID = securefileid
+            ' End If
             RootPath = savedir
             If File.Exists(savedir & "\ICON0.PNG") Then
                 'prevent file lock,reading to memory instead.
                 SaveImage = Image.FromStream(New MemoryStream(File.ReadAllBytes(savedir & "\ICON0.PNG")))
             End If
 
-            Files = (From ent In Param_PFD.Entries Let x = New FileInfo(savedir & "\" & Convert.ToString(ent.file_name)) Where x.Extension.ToUpper() <> ".PFD" AndAlso x.Extension.ToUpper() <> ".SFO" Select New Ps3File(savedir & "\" & Convert.ToString(ent.file_name), ent, Me)).ToArray()
+            ' Files = (From ent In Param_PFD.Entries Let x = New FileInfo(savedir & "\" & Convert.ToString(ent.file_name)) Where x.Extension.ToUpper() <> ".PFD" AndAlso x.Extension.ToUpper() <> ".SFO" Select New Ps3File(savedir & "\" & Convert.ToString(ent.file_name), ent, Me)).ToArray()
+            Files = (From file_path In Directory.GetFiles(savedir) Let x = New FileInfo(file_path) Where x.Extension.ToUpper() <> ".PFD" AndAlso x.Extension.ToUpper() <> ".SFO" Select New Ps3File(file_path, Nothing, Me)).ToArray()
         End Sub
 
         Public Property RootPath() As String


### PR DESCRIPTION
Firstly, thanks for your work Wulf! Secondly, I don't actually expect this to be merged since it's a complete mess, but hopefully it's useful to someone.

This patch allows editing saved games from RPCS3.

Essentially it just chops out the `PARAM.PFD` handling and skips encrypting/decrypting files. I also had to use `USER.DAT` instead of `1USER.DAT` for whatever reason (I have no idea what I'm doing). I also also didn't bother writing to `PARAM.SFO` and `104USER.DAT` since I didn't need them and didn't want to break stuff, but they could easily be re-enabled.

Here's the Monk's Head Wrappings I edited in for proof 😄 
![image](https://user-images.githubusercontent.com/703055/62002741-408c1b00-b14e-11e9-9d63-6682778c9fa4.png)
